### PR TITLE
Update build instructions for CentOS and Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Currently tested attributes are:
 ## Building
 
 Install the following packages:
- * `libaio-devel` (`libaio-dev1` on Debian and derivatives)
+ * `libaio-devel` (`libaio-dev` on Debian and derivatives)
+ * `xfsprogs-devel.x86_64` (`xfslibs-dev` on Debian and derivatives)
  * `gcc-c++` (`g++` on Debian and derivatives)
  * `make`
 


### PR DESCRIPTION
_Note: I didn't spot a contribution process for this repo, but am aware ScyllaDB itself uses mailing list submission. If patches are preferred via a different mechanism please let me know and I'll use that!_

Building now requires XFS-specific headers (`xfsprogs-devel.x86_64` on CentOS, and `xfslibs-dev` on Debian derivatives). Additionally, the package name for `libaio` headers and libraries on Debian in recent versions is `libaio-dev` rather than `libaio-dev1`.

This PR updates the README to reflect these changes.