### PR TITLE
Allow qualification to be done with NOWAIT AIO support (RWF_NOWAIT)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 CXXFLAGS = -O2 -g -std=gnu++11
-LDLIBS = -laio
+LDLIBS = -laio -lboost_program_options
 
 fsqual: fsqual.cc


### PR DESCRIPTION
$ sudo ~/fsqual/fsqual
memory DMA alignment:         512
disk DMA read alignment:      512
disk DMA write alignment:      512
context switch per appending io (mode size-changing, iodepth 1): 0 (GOOD)
context switch per appending io (mode size-changing, iodepth 3): 0.7932 (BAD)
context switch per appending io (mode size-unchanging, iodepth 3): 0.0002 (GOOD)
context switch per appending io (mode size-unchanging, iodepth 7): 0.0001 (GOOD)

$ sudo ~/fsqual/fsqual --nowait
memory DMA alignment:         512
disk DMA read alignment:      512
disk DMA write alignment:      512
context switch per appending io (mode size-changing, iodepth 1): 0 (GOOD)
context switch per appending io (mode size-changing, iodepth 3): 0 (GOOD)
context switch per appending io (mode size-unchanging, iodepth 3): 0 (GOOD)
context switch per appending io (mode size-unchanging, iodepth 7): 0 (GOOD)

$ sudo ~/fsqual/fsqual --help
Usage: /home/raphaelsc/fsqual/fsqual <option(s)>
Options:
	-h,--help		Show this help message
	--nowait	Use NOWAIT AIO (RWF_NOWAIT flag)

Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>